### PR TITLE
Config option for RaspberryPi bluepy fix

### DIFF
--- a/mi-scale/README.md
+++ b/mi-scale/README.md
@@ -35,6 +35,7 @@ Name | Model | Picture
 Option | Type | Required | Description
 --- | --- | --- | ---
 HCI_DEV | string | No | Bluetooth hci device to use. Defaults to hci0
+RPI_BLUEPY_FIX | bool | No | Activates potential fix for Bluepy issues on RaspberryPi "scan(5, passive=true)"
 MISCALE_MAC | string | Yes | Mac address of your scale
 MQTT_PREFIX | string | No | MQTT Topic Prefix. Defaults to miscale
 MQTT_HOST | string | Yes | MQTT Server (defaults to 127.0.0.1)

--- a/mi-scale/config.json
+++ b/mi-scale/config.json
@@ -14,6 +14,7 @@
 
   "options": {
     "HCI_DEV": "hci0",
+    "RPI_BLUEPY_FIX": "false",
     "MISCALE_MAC": "00:00:00:00:00:00",
     "MQTT_PREFIX": "miscale",
     "MQTT_HOST": "192.168.0.1",
@@ -44,6 +45,7 @@
   },
   "schema": {
     "HCI_DEV": "str?",
+    "RPI_BLUEPY_FIX": "bool?",
     "MISCALE_MAC": "str",
     "MQTT_PREFIX": "str?",
     "MQTT_HOST": "str",

--- a/mi-scale/src/Xiaomi_Scale.py
+++ b/mi-scale/src/Xiaomi_Scale.py
@@ -79,6 +79,11 @@ try:
             HCI_DEV = "hci0"[-1]
             pass
         try:
+            RPI_BLUEPY_FIX = data["RPI_BLUEPY_FIX"]
+        except:
+            RPI_BLUEPY_FIX = False
+            pass                     
+        try:
             USER1_GT = int(data["USER1_GT"])
         except:
             sys.stderr.write(f"{datetime.now().strftime('%Y-%m-%d %H:%M:%S')} - USER1_GT not provided...\n")
@@ -317,7 +322,10 @@ def main():
     while True:
         try:
             scanner = btle.Scanner(HCI_DEV).withDelegate(ScanProcessor())
-            scanner.scan(5) # Adding passive=True to try and fix issues on RPi devices
+            if RPI_BLUEPY_FIX.lower() in ['true', '1', 'y', 'yes']:
+                scanner.scan(5, passive=True) #passive=True to try and fix issues for bluepy on RPi devices
+            else:
+                scanner.scan(5)
         except BTLEDisconnectError as error:
             sys.stderr.write(f"{datetime.now().strftime('%Y-%m-%d %H:%M:%S')} - btle disconnected: {error}\n")
             pass


### PR DESCRIPTION
Makes the RaspberryPi Bluepy fix "scan(5**, passive=true**)" configurable in the add-on config.

This fix resolves all the issues on my RaspberryPi 4 with a Body Composition Scale 2.